### PR TITLE
Add go implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ List of IDMEF implementations, documentation, ...
 
  - [php-idmef](https://github.com/fpoirotte/php-idmef)
 
+ - [go-idmef](https://github.com/grokify/go-idmef)
+
 ## Security probes with IDMEF support
 
  - [Suricata](http://suricata-ids.org/)


### PR DESCRIPTION
A Go (aka golang) implementation of the IDMEF message format has been created at:

https://github.com/grokify/go-idmef

It contains the RFC Section 7 examples as tests with raw XML files and Go code:

https://github.com/grokify/go-idmef/tree/master/testdata

Please add it to the implementation list.